### PR TITLE
chr 104 fix fonts

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -2,6 +2,7 @@
 @import 'tailwindcss';
 
 @plugin '@tailwindcss/forms';
+@plugin '@tailwindcss/typography';
 
 @theme {
 	--font-geistmono: 'Geist Mono', sans-serif;

--- a/src/app.css
+++ b/src/app.css
@@ -1,7 +1,11 @@
+@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&display=swap');
 @import 'tailwindcss';
 
-@plugin '@tailwindcss/typography';
 @plugin '@tailwindcss/forms';
+
+@theme {
+	--font-geistmono: 'Geist Mono', sans-serif;
+}
 
 /*
   The default border color has changed to `currentColor` in Tailwind CSS v4,
@@ -12,11 +16,11 @@
   color utility to any element that depends on these defaults.
 */
 @layer base {
-  *,
-  ::after,
-  ::before,
-  ::backdrop,
-  ::file-selector-button {
-    border-color: var(--color-gray-200, currentColor);
-  }
+	*,
+	::after,
+	::before,
+	::backdrop,
+	::file-selector-button {
+		border-color: var(--color-gray-200, currentColor);
+	}
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,17 +2,17 @@
 	import { page } from '$app/stores';
 	import NavLink from '$lib/NavLink.svelte';
 	import '../app.css';
+
 	let { children } = $props();
-	console.log($page);
 </script>
 
-<div class="mx-2 font-mono">
+<div class="font-geistmono mx-2">
 	<nav class="my-2 flex gap-2">
 		<NavLink to="/" title="home" />
 		<NavLink to="/twin" title="twin" />
 		<NavLink to="/sensors" title="sensors" />
 		<NavLink to="/readings" title="readings" />
 	</nav>
-	<p class="mb-2">Currently at {$page.url.pathname}</p>
+	<p class="mb-2 text-2xl font-bold">{$page.url.pathname}</p>
 	{@render children()}
 </div>

--- a/src/routes/readings/+page.svelte
+++ b/src/routes/readings/+page.svelte
@@ -18,8 +18,6 @@
 	console.log(data);
 </script>
 
-<h1 class="text-2xl font-bold lowercase">readings</h1>
-
 <h2 class="text-xl font-semibold lowercase">daily</h2>
 <div class="grid grid-cols-8 font-mono">
 	<p class="font-bold">sensor_id</p>

--- a/src/routes/sensors/+page.svelte
+++ b/src/routes/sensors/+page.svelte
@@ -10,8 +10,6 @@
 	});
 </script>
 
-<h1 class="text-2xl font-bold lowercase">Sensors</h1>
-
 <div class="grid grid-cols-4">
 	<p class="font-mono font-bold">sensor_id</p>
 	<p class="font-mono font-bold">sensor_name</p>

--- a/src/routes/twin/+page.svelte
+++ b/src/routes/twin/+page.svelte
@@ -1,1 +1,0 @@
-<h1 class="text-2xl font-bold lowercase">Twin</h1>


### PR DESCRIPTION
### Description

This pull request includes several changes to the styling and layout of the application. The most important changes involve the addition of a new font, updates to the typography plugin, and modifications to the layout and styling of various pages.

Styling updates:

* [`src/app.css`](diffhunk://#diff-e269447b167c1d69748b9d5ccde405e2fb2d74af0d1832d5c05e63362816722dR1-R9): Added the `Geist Mono` font from Google Fonts, updated the Tailwind CSS typography plugin, and introduced a new theme variable for the `Geist Mono` font.

Layout and styling modifications:

* [`src/routes/+layout.svelte`](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dR5-R16): Applied the new `font-geistmono` class to the main layout, removed a console log statement, and adjusted the styling of the page URL display.
* [`src/routes/readings/+page.svelte`](diffhunk://#diff-24b8c7c48935d50a57cdded02328015cafc76acf75d029b5b6b9844c73464130L21-L22): Removed the `<h1>` element for the "readings" title.
* [`src/routes/sensors/+page.svelte`](diffhunk://#diff-a4c7b9d613df2d61414514ac6650fa4ef7b199a32f4ea36fa8078ee8c46be1fcL13-L14): Removed the `<h1>` element for the "Sensors" title.
* [`src/routes/twin/+page.svelte`](diffhunk://#diff-2d4886b7601bdb582b3368bbd2bb43b6569b54f4aae2e1980d420c5f63550272L1): Removed the `<h1>` element for the "Twin" title.

### Changelist

* 52e007a refactor: remove page titles
* 0fb0ce9 fix: re-add missing tailwindcss/typography plugin
* 4da9dc0 feat: add font to global layout
* b01f267 feat: add geist mono font to imports